### PR TITLE
Update go.sh

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -7,6 +7,10 @@ echo "Wait..."
 sleep 3s
 echo -e "\n"
 
+sudo echo $DBPASS > /root/MYSQL_PWD
+
+sudo apt-get -y install dnsutils
+
 #VARS
 IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
 


### PR DESCRIPTION
- Install dnsutils package (to use "dig" command)
- Safe-copy MySQL password to /root/MYSQL_PWD


--
Ho aggiunto dnsutils perché mi è capitato di installarlo per prova su un server UpCloud e non era presente di default questo pacchetto, di conseguenza non riusciva a determinare l'host.

Ho aggiunto anche il salvataggio della password MySQL, poiché - sempre su un server UpCloud - non l'ha salvata automaticamente nel file .env (non ho approfondito il motivo, ma due server su due hanno fallito il salvataggio nel file .env).