### PR TITLE
interrupted installation 

### DIFF
--- a/setup/18.sh
+++ b/setup/18.sh
@@ -66,13 +66,6 @@ sleep 3s
 sudo apt-get update
 sudo apt-get -y install rpl zip unzip curl dirmngr apt-transport-https lsb-release ca-certificates dnsutils htop
 
-
-sudo rpl -i -w "#PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
-sudo rpl -i -w "# PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
-sudo rpl -i -w "PasswordAuthentication no" "PasswordAuthentication yes" /etc/ssh/sshd_config
-sudo rpl -i -w "PermitRootLogin yes" "PermitRootLogin no" /etc/ssh/sshd_config
-sudo service sshd restart
-
 WELCOME=/etc/motd
 sudo touch $WELCOME
 sudo cat > "$WELCOME" <<EOF
@@ -391,6 +384,12 @@ EOF
 crontab $TASK
 
 sudo systemctl restart nginx.service
+
+sudo rpl -i -w "#PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
+sudo rpl -i -w "# PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
+sudo rpl -i -w "PasswordAuthentication no" "PasswordAuthentication yes" /etc/ssh/sshd_config
+sudo rpl -i -w "PermitRootLogin yes" "PermitRootLogin no" /etc/ssh/sshd_config
+sudo service sshd restart
 
 clear
 echo "Cipi installation has been completed... Wait for your data!"

--- a/setup/20.sh
+++ b/setup/20.sh
@@ -67,12 +67,6 @@ sudo apt-get update
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get -y install rpl zip unzip openssl curl expect dirmngr apt-transport-https lsb-release ca-certificates dnsutils htop
 
-sudo rpl -i -w "#PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
-sudo rpl -i -w "# PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
-sudo rpl -i -w "PasswordAuthentication no" "PasswordAuthentication yes" /etc/ssh/sshd_config
-sudo rpl -i -w "PermitRootLogin yes" "PermitRootLogin no" /etc/ssh/sshd_config
-sudo service sshd restart
-
 WELCOME=/etc/motd
 sudo touch $WELCOME
 sudo cat > "$WELCOME" <<EOF
@@ -415,6 +409,12 @@ EOF
 crontab $TASK
 
 sudo systemctl restart nginx.service
+
+sudo rpl -i -w "#PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
+sudo rpl -i -w "# PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
+sudo rpl -i -w "PasswordAuthentication no" "PasswordAuthentication yes" /etc/ssh/sshd_config
+sudo rpl -i -w "PermitRootLogin yes" "PermitRootLogin no" /etc/ssh/sshd_config
+sudo service sshd restart
 
 clear
 echo "Cipi installation has been completed... Wait for your data!"

--- a/storage/app/scripts/install.sh
+++ b/storage/app/scripts/install.sh
@@ -110,12 +110,6 @@ sleep 3s
 sudo apt-get update
 sudo apt-get -y install nano rpl sed zip unzip openssl expect dirmngr apt-transport-https lsb-release ca-certificates dnsutils dos2unix zsh htop
 
-sudo rpl -i -w "#PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
-sudo rpl -i -w "# PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
-sudo rpl -i -w "PasswordAuthentication no" "PasswordAuthentication yes" /etc/ssh/sshd_config
-sudo rpl -i -w "PermitRootLogin yes" "PermitRootLogin no" /etc/ssh/sshd_config
-sudo service sshd restart
-
 WELCOME=/etc/motd
 sudo touch $WELCOME
 sudo cat > "$WELCOME" <<EOF
@@ -800,6 +794,12 @@ EOF
 crontab $TASK
 
 sudo systemctl restart nginx.service
+
+sudo rpl -i -w "#PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
+sudo rpl -i -w "# PasswordAuthentication" "PasswordAuthentication" /etc/ssh/sshd_config
+sudo rpl -i -w "PasswordAuthentication no" "PasswordAuthentication yes" /etc/ssh/sshd_config
+sudo rpl -i -w "PermitRootLogin yes" "PermitRootLogin no" /etc/ssh/sshd_config
+sudo service sshd restart
 
 curl --request GET --url $REMOTE/remote/finalize/$SERVERCODE
 


### PR DESCRIPTION
Cannot continue installation because it require interactive prompt about openssh-server configuration (sshd_config) that already modified before upgrade repositories.

I move down the sshd_config modifying task. or maybe need to add `export DEBIAN_FRONTEND=noninteractive` before command update and upgrade the repo.

OS : Ubuntu 20.04

the image below illustrate the prompt text something like this but in bw color and cannot choosed :) 
<img width="350" src="https://user-images.githubusercontent.com/486669/88891170-4642a200-d275-11ea-947d-69ffde993169.png">

